### PR TITLE
bugfix?

### DIFF
--- a/lib/task-runner.js
+++ b/lib/task-runner.js
@@ -1,22 +1,24 @@
 'use babel';
 
-import ChildProcess from 'child_process';
+import ChildProcess from 'child_process'; 
 import { Map } from 'immutable';
 
 import Task from './task';
 
 const spawn = ChildProcess.spawn;
+const exec2 = ChildProcess.exec;
 
 function exec(task) {
 
     return new Promise((resolve, reject) => {
-        const thread = spawn(
-            atom.config.get('package-script-runner.manager') || 'yarn',
-            ['run', ... task.cmd.split(' ')],
+        const thread = exec2(
+            (atom.config.get('package-script-runner.manager') || 'yarn')+
+            ' run '+
+              task.cmd,
             {
                 cwd: task.cwd,
-                shell: false,
-                detached: true,
+                shell: false//,
+                //detached: true,
             }
         );
 


### PR DESCRIPTION
using child_process.exec
it is solving error`'yarn' could not be spawned. Is it installed and on your path? If so please open an issue on the package spawning the process.` on my atom editor 
I am using windows10, atom 1.53.0